### PR TITLE
Create reseticoncache.bat

### DIFF
--- a/reseticoncache.bat
+++ b/reseticoncache.bat
@@ -1,0 +1,4 @@
+taskkill /f /im explorer.exe
+cd /d %userprofile%\AppData\Local
+del IconCache.db /a
+start explorer.exe


### PR DESCRIPTION
Resets the icon cache so it could reload the icons. could be useful if a icon isnt showing as its suppose to (like its showing up as a white default icon).